### PR TITLE
Add virtual environment instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,25 @@
 # Waitingblock
 ## A Basic Django Waitinglist App built using [django_tables2](https://github.com/jieter/django-tables2), [Bootstrap4](https://getbootstrap.com/)
 
-For development environment, recommend install per [Django Girls Tutorial](https://tutorial.djangogirls.org/en/django_installation/) into the **Waitingblock-master** directory
+Ensure you have virtualenv installed and on your path
+
+```
+which virtualenv
+```
+
+should return anything other than `virtualenv not found`
+
+Create a new virtual environment with your machine's python3 as the default python
+
+```
+virtualenv -p python3 myenv 
+``` 
+
+Activate your virtual environment
+
+```
+source myenv/bin/activate
+```
 
 Install the required dependencies for this project:
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ source myenv/bin/activate
 Install the required dependencies for this project:
 
 ```
-python3 -m pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
 Build the database by running all available migrations:
 
 ```
-python3 manage.py migrate
+python manage.py migrate
 ```
 
 We can set up our local server from the **Waitingblock** directory
@@ -41,5 +41,5 @@ python manage.py runserver
 If you'd like to use this in production, please make sure to set the `SECRET_KEY` environment variable, like so:
 
 ```
-SECRET_KEY=<a_secret_key> python3 manage.py runserver
+SECRET_KEY=<a_secret_key> python manage.py runserver
 ```


### PR DESCRIPTION
This makes the readme self-contained.  It's bad practice to require potential developers to click an external link to get started.